### PR TITLE
fix: display chart titles above titles

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -28,12 +28,12 @@ document.addEventListener("DOMContentLoaded", function () {
         // Calls the add_canvas_to_html function.
         add_canvas_to_html("spending", "chart_area");
         // Calls the create_chart function.
-        create_chart("spending", "Annual Spending Breakdown 2022 - 2023", selects_value, values_value, barColors);
+        create_chart("spending", "Your Bucket Breakdown", selects_value, values_value, barColors);
 
         // Calls the add_canvas_to_html function.
         add_canvas_to_html("sample", "bucket_chart_area");
         // Calls the create_chart function.
-        create_chart("sample", "Sample 5 bucket Spending Breakdown", ["Expenses", "Emergency", "Investment", "Learning", "Fun"], [60, 10, 10, 10, 10], barColors);
+        create_chart("sample", "5 Bucket Theory Breakdown", ["Expenses", "Emergency", "Investment", "Learning", "Fun"], [60, 10, 10, 10, 10], barColors);
     });
 
     // Checks to see if the add user input row button has been clicked

--- a/calculator.html
+++ b/calculator.html
@@ -586,7 +586,8 @@
             </div>
         </div>
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js">
+    </script>
     <!--Currency Converter Script-->
     <script src="assets/scripts/currency.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>


### PR DESCRIPTION
Chart.js charts now display the title:
- Bug was caused by the wrong version of chart.js being loaded.
- I have also updated the chart titles to follow the style recommended in the chat